### PR TITLE
[Android] notification with inline reply 

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,28 @@ import PushNotificationAndroid from 'react-native-push-notification'
 })();
 ```
 
+Notifications with inline reply: 
+
+You must register an action as "ReplyInput", this will show in the notifications an input to write in. 
+
+EXAMPLE:
+```javascript
+PushNotification.localNotificationSchedule({
+  message: "My Notification Message", // (required)
+  date: new Date(Date.now() + (60 * 1000)), // in 60 secs
+  actions: '["ReplyInput"]',
+  reply_placeholder_text: "Write your response...", // (required)
+  reply_button_text: "Reply" // (required)
+});
+```
+
+To get the text from the notification: 
+
+```javascript
+const info = JSON.parse(action.dataJSON);
+info.reply_text // this will contain the inline reply text. 
+```
+
 For iOS, you can use this [package](https://github.com/holmesal/react-native-ios-notification-actions) to add notification actions.
 
 ## Set application badge icon

--- a/README.md
+++ b/README.md
@@ -321,8 +321,11 @@ PushNotification.localNotificationSchedule({
 To get the text from the notification: 
 
 ```javascript
+DeviceEventEmitter.addListener('notificationActionReceived', function(action){ 
+...
 const info = JSON.parse(action.dataJSON);
 info.reply_text // this will contain the inline reply text. 
+...
 ```
 
 For iOS, you can use this [package](https://github.com/holmesal/react-native-ios-notification-actions) to add notification actions.

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -8,6 +8,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import android.app.RemoteInput;
+import android.util.Log;
+
 
 import com.dieam.reactnativepushnotification.helpers.ApplicationBadgeHelper;
 import com.facebook.react.bridge.ActivityEventListener;
@@ -31,6 +34,7 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
     private RNPushNotificationHelper mRNPushNotificationHelper;
     private final Random mRandomNumberGenerator = new Random(System.currentTimeMillis());
     private RNPushNotificationJsDelivery mJsDelivery;
+    private static final String KEY_TEXT_REPLY = "key_text_reply";
 
     public RNPushNotification(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -93,6 +97,15 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
             @Override
             public void onReceive(Context context, Intent intent) {
                 Bundle bundle = intent.getBundleExtra("notification");
+                Bundle remoteInput = null;
+
+                if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT_WATCH){
+                    remoteInput = RemoteInput.getResultsFromIntent(intent);
+                }
+                if (remoteInput != null) {
+                    // Add to reply_text the text written by the user in the notification
+                    bundle.putCharSequence("reply_text", remoteInput.getCharSequence(KEY_TEXT_REPLY));
+                }
 
                 // Notify the action.
                 mJsDelivery.notifyNotificationAction(bundle);

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -9,7 +9,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
 import android.app.RemoteInput;
-import android.util.Log;
 
 
 import com.dieam.reactnativepushnotification.helpers.ApplicationBadgeHelper;

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -105,7 +105,6 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
                     // Add to reply_text the text written by the user in the notification
                     bundle.putCharSequence("reply_text", remoteInput.getCharSequence(KEY_TEXT_REPLY));
                 }
-
                 // Notify the action.
                 mJsDelivery.notifyNotificationAction(bundle);
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationAttributes.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationAttributes.java
@@ -36,6 +36,8 @@ public class RNPushNotificationAttributes {
     private static final String REPEAT_TYPE = "repeatType";
     private static final String REPEAT_TIME = "repeatTime";
     private static final String ONGOING = "ongoing";
+    private static final String REPLY_BUTTON_TEXT = "reply_button_text";
+    private static final String REPLAY_PLACEHOLDER_TEXT = "reply_placeholder_text";
 
     private final String id;
     private final String message;
@@ -60,6 +62,8 @@ public class RNPushNotificationAttributes {
     private final String repeatType;
     private final double repeatTime;
     private final boolean ongoing;
+    private final String reply_button_text;
+    private final String reply_placeholder_text;
 
     public RNPushNotificationAttributes(Bundle bundle) {
         id = bundle.getString(ID);
@@ -85,6 +89,8 @@ public class RNPushNotificationAttributes {
         repeatType = bundle.getString(REPEAT_TYPE);
         repeatTime = bundle.getDouble(REPEAT_TIME);
         ongoing = bundle.getBoolean(ONGOING);
+        reply_button_text = bundle.getString(REPLY_BUTTON_TEXT);
+        reply_placeholder_text = bundle.getString(REPLAY_PLACEHOLDER_TEXT);
     }
 
     private RNPushNotificationAttributes(JSONObject jsonObject) {
@@ -112,6 +118,8 @@ public class RNPushNotificationAttributes {
             repeatType = jsonObject.has(REPEAT_TYPE) ? jsonObject.getString(REPEAT_TYPE) : null;
             repeatTime = jsonObject.has(REPEAT_TIME) ? jsonObject.getDouble(REPEAT_TIME) : 0.0;
             ongoing = jsonObject.has(ONGOING) ? jsonObject.getBoolean(ONGOING) : false;
+            reply_button_text = jsonObject.has(REPLY_BUTTON_TEXT) ? jsonObject.getString(REPLY_BUTTON_TEXT) : null;
+            reply_placeholder_text = jsonObject.has(REPLAY_PLACEHOLDER_TEXT) ? jsonObject.getString(REPLAY_PLACEHOLDER_TEXT) : null;
         } catch (JSONException e) {
             throw new IllegalStateException("Exception while initializing RNPushNotificationAttributes from JSON", e);
         }
@@ -197,6 +205,8 @@ public class RNPushNotificationAttributes {
         bundle.putString(REPEAT_TYPE, repeatType);
         bundle.putDouble(REPEAT_TIME, repeatTime);
         bundle.putBoolean(ONGOING, ongoing);
+        bundle.putString(REPLY_BUTTON_TEXT, reply_button_text);
+        bundle.putString(REPLAY_PLACEHOLDER_TEXT, reply_placeholder_text);
         return bundle;
     }
 
@@ -226,6 +236,8 @@ public class RNPushNotificationAttributes {
             jsonObject.put(REPEAT_TYPE, repeatType);
             jsonObject.put(REPEAT_TIME, repeatTime);
             jsonObject.put(ONGOING, ongoing);
+            jsonObject.put(REPLY_BUTTON_TEXT, reply_button_text);
+            jsonObject.put(REPLAY_PLACEHOLDER_TEXT, reply_placeholder_text);
         } catch (JSONException e) {
             Log.e(LOG_TAG, "Exception while converting RNPushNotificationAttributes to " +
                     "JSON. Returning an empty object", e);
@@ -261,6 +273,8 @@ public class RNPushNotificationAttributes {
                 ", repeatType='" + repeatType + '\'' +
                 ", repeatTime=" + repeatTime +
                 ", ongoing=" + ongoing +
+                ", reply_button_text=" + reply_button_text +
+                ", reply_placeholder_text=" + reply_placeholder_text +
                 '}';
     }
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -323,7 +323,6 @@ public class RNPushNotificationHelper {
                                     .build();
 
                             notification.addAction(replyAction);
-
                         }
                         else{
                             // The notification will not have action

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -302,16 +302,38 @@ public class RNPushNotificationHelper {
                         Log.e(LOG_TAG, "Exception while getting action from actionsArray.", e);
                         continue;
                     }
-
                     Intent actionIntent = new Intent();
                     actionIntent.setAction(context.getPackageName() + "." + action);
-                    // Add "action" for later identifying which button gets pressed.
                     bundle.putString("action", action);
                     actionIntent.putExtra("notification", bundle);
                     PendingIntent pendingActionIntent = PendingIntent.getBroadcast(context, notificationID, actionIntent,
                             PendingIntent.FLAG_UPDATE_CURRENT);
-                    notification.addAction(icon, action, pendingActionIntent);
-                }
+                    if(action.equals("ReplyInput")){
+                        //action with inline reply
+                        if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT_WATCH){
+                            final String KEY_TEXT_REPLY = "key_text_reply";
+
+                            RemoteInput remoteInput = new RemoteInput.Builder(KEY_TEXT_REPLY)
+                                    .setLabel(bundle.getString("reply_placeholder_text"))
+                                    .build();
+                            NotificationCompat.Action replyAction = new NotificationCompat.Action.Builder(
+                                    icon, bundle.getString("reply_button_text"), pendingActionIntent)
+                                    .addRemoteInput(remoteInput)
+                                    .setAllowGeneratedReplies(true)
+                                    .build();
+
+                            notification.addAction(replyAction);
+
+                        }
+                        else{
+                            // the notification will not have action
+                            break;
+                        }
+                    }
+                    else{
+                        // Add "action" for later identifying which button gets pressed
+                        notification.addAction(icon, action, pendingActionIntent);
+                    }
             }
 
             // Remove the notification from the shared preferences once it has been shown

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -40,6 +40,8 @@ public class RNPushNotificationHelper {
     private static final int ONE_MINUTE = 60 * 1000;
     private static final long ONE_HOUR = 60 * ONE_MINUTE;
     private static final long ONE_DAY = 24 * ONE_HOUR;
+    private static final String KEY_TEXT_REPLY = "key_text_reply";
+
 
     public RNPushNotificationHelper(Application context) {
         this.context = context;
@@ -309,10 +311,8 @@ public class RNPushNotificationHelper {
                     PendingIntent pendingActionIntent = PendingIntent.getBroadcast(context, notificationID, actionIntent,
                             PendingIntent.FLAG_UPDATE_CURRENT);
                     if(action.equals("ReplyInput")){
-                        //action with inline reply
+                        //Action with inline reply
                         if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT_WATCH){
-                            final String KEY_TEXT_REPLY = "key_text_reply";
-
                             RemoteInput remoteInput = new RemoteInput.Builder(KEY_TEXT_REPLY)
                                     .setLabel(bundle.getString("reply_placeholder_text"))
                                     .build();
@@ -326,7 +326,7 @@ public class RNPushNotificationHelper {
 
                         }
                         else{
-                            // the notification will not have action
+                            // The notification will not have action
                             break;
                         }
                     }


### PR DESCRIPTION
**Summary**

Added an action "ReplyInput" that will show in the notification a button with an inline reply (an input to write in).

**Changes Introduced**

When configuring the actions from React Native it is required to register an action named "ReplyInput", then schedule the notification with the action parameter as "ReplyInput" and two more parameters:

- reply_placeholder_text (Text shown in the placeholder of the input)
- reply_button_text (Action button text)

When the user writes in the input and press the send button, a parameter is added in the bundle to pass it to React Native. To get the text, you will receive it in "action.dataJSON" as "reply_text".

**Documentation:**

https://developer.android.com/guide/topics/ui/notifiers/notifications.html#inline-reply-action
Updated Readme with a code explanation